### PR TITLE
Fix in gitignore to avoid removing BMEGlobal.temp.h from the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 ####
 # Be My Eyes specific files
 BeMyEyes/Source/BMEGlobal.h
+BeMyEyes/Source/BMEGlobal.temp.h
  
 #####
 # OS X temporary files that should never be committed
@@ -138,3 +139,4 @@ xcuserdata
 # and should therefore not be checked into the VCS.
 
 *.xccheckout
+


### PR DESCRIPTION
When you rename it git marks it as "deleted", and if you do something like `git commit -am "my changes"` (which is what I usually do) you would delete the file from the repo. Including it in .gitignore ensures no one will delete it by accident.