### PR TITLE
Profile image selection

### DIFF
--- a/BeMyEyes/Base.lproj/Main.storyboard
+++ b/BeMyEyes/Base.lproj/Main.storyboard
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14A389" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="pPv-pk-tQL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="pPv-pk-tQL">
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
@@ -1340,7 +1339,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
                                             <constraint firstAttribute="trailing" secondItem="OHO-hf-tdb" secondAttribute="trailing" id="wvd-ja-Gea"/>
                                         </constraints>
                                     </view>
-                                    <view hidden="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EB3-Hs-pVj" userLabel="Separator 2">
+                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EB3-Hs-pVj" userLabel="Separator 2">
                                         <rect key="frame" x="107" y="47" width="21" height="5"/>
                                         <color key="backgroundColor" red="0.0" green="1" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
@@ -1527,7 +1526,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6AN-ix-uS6" userLabel="Helped persons">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6AN-ix-uS6" userLabel="Helped persons">
                                             <rect key="frame" x="8" y="210" width="142" height="68"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OdZ-Jb-0ah" customClass="BMEPointLabel">
@@ -1555,7 +1554,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
                                                 <constraint firstItem="OdZ-Jb-0ah" firstAttribute="top" secondItem="6AN-ix-uS6" secondAttribute="top" id="wur-QF-VbI"/>
                                             </constraints>
                                         </view>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L93-LG-eip" userLabel="Total points">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="L93-LG-eip" userLabel="Total points">
                                             <rect key="frame" x="170" y="210" width="142" height="68"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="50" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iea-OD-NO6" customClass="BMEPointLabel">
@@ -1589,7 +1588,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
                                                 <constraint firstAttribute="height" constant="40" id="9Ai-bh-aHa"/>
                                             </constraints>
                                         </view>
-                                        <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pl8-pe-Xnt" userLabel="User type + level">
+                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pl8-pe-Xnt" userLabel="User type + level">
                                             <rect key="frame" x="108" y="186" width="104" height="14"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New Helper" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDk-Fp-G2F">
@@ -1615,6 +1614,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
                                         </view>
                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="ProfileFilledInSquare" translatesAutoresizingMaskIntoConstraints="NO" id="nD0-Ei-SWE" customClass="ProfileImageView" customModule="BeMyEyes" customModuleProvider="target">
                                             <rect key="frame" x="110" y="40" width="100" height="100"/>
+                                            <gestureRecognizers/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="100" id="U7U-Gu-nr1"/>
                                                 <constraint firstAttribute="width" secondItem="nD0-Ei-SWE" secondAttribute="height" id="yEK-Kx-6RB"/>
@@ -1784,16 +1784,16 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
                                             <constraint firstItem="U8b-Va-Uxg" firstAttribute="top" secondItem="3vn-oO-1sp" secondAttribute="bottom" constant="-5" id="g1a-ev-iTd"/>
                                         </constraints>
                                     </view>
-                                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n6C-cj-jhc" userLabel="Helped">
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n6C-cj-jhc" userLabel="Helped">
                                         <rect key="frame" x="213" y="61" width="103" height="55"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Helped" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6FE-RA-1MY">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Helped" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6FE-RA-1MY">
                                                 <rect key="frame" x="0.0" y="38" width="103" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="2.02M" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="936-Cz-Ktx" customClass="BMEPointLabel">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2.02M" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="936-Cz-Ktx" customClass="BMEPointLabel">
                                                 <rect key="frame" x="0.0" y="0.0" width="103" height="43"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
                                                 <nil key="highlightedColor"/>
@@ -1915,7 +1915,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iJh-xD-Sg7" userLabel="Name View">
                                                 <rect key="frame" x="15" y="91" width="290" height="60"/>
                                                 <subviews>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Surname" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2KI-e2-g2G">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Surname" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2KI-e2-g2G">
                                                         <rect key="frame" x="171" y="0.0" width="109" height="60"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="60" id="8Yb-vE-kjH"/>

--- a/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
+++ b/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
@@ -19,6 +19,7 @@
 #import "BMEPointsTableViewCell.h"
 #import <SDWebImage/UIImageView+WebCache.h>
 #import "BeMyEyes-Swift.h"
+#import <PSTAlertController.h>
 
 #define BMEHelperSnoozeAmount0 0.0f
 #define BMEHelperSnoozeAmount25 3600.0f
@@ -34,7 +35,7 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
     BMESnoozeStep100
 };
 
-@interface BMEHelperMainViewController () <UIGestureRecognizerDelegate, UITableViewDataSource, UITableViewDelegate>
+@interface BMEHelperMainViewController () <UIGestureRecognizerDelegate, UITableViewDataSource, UITableViewDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate>
 @property (weak, nonatomic) IBOutlet UILabel *nameLabel;
 @property (weak, nonatomic) IBOutlet UILabel *levelLabel;
 
@@ -125,6 +126,12 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
     UIPanGestureRecognizer *panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
     panGesture.delegate = self;
     [self.view addGestureRecognizer:panGesture];
+    
+    UITapGestureRecognizer *photoTapRecognizer =
+    [[UITapGestureRecognizer alloc] initWithTarget: self
+                                            action: @selector(profileImageViewTapped:)];
+    [self.profileImageView addGestureRecognizer: photoTapRecognizer];
+    self.profileImageView.userInteractionEnabled = YES;
     
     [self snapSnoozeSliderToStep:BMESnoozeStep0 animated:NO];
     
@@ -403,11 +410,7 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
     return cell;
 }
 
-
 #pragma mark - Setters and Getters
-
-
-#pragma mark – Setters and Getters
 
 - (void)setUser:(BMEUser *)user
 {
@@ -425,6 +428,61 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
         
         [self updateStatsPointsAnimated:NO];
     }
+}
+
+#pragma mark - Profile photo selection
+
+- (void) profileImageViewTapped: (UITapGestureRecognizer*) tapRecognizer
+{
+    PSTAlertController *actionSheet =
+    [PSTAlertController alertControllerWithTitle: @"Add profile photo"
+                                         message: nil
+                                  preferredStyle: PSTAlertControllerStyleActionSheet];
+    
+    if ([UIImagePickerController isSourceTypeAvailable: UIImagePickerControllerSourceTypeCamera])
+    {
+        PSTAlertAction *takeNewAction =
+        [PSTAlertAction actionWithTitle: @"Take new"
+                                handler:^(PSTAlertAction *action) {
+                                    UIImagePickerController *pickerController = [UIImagePickerController new];
+                                    pickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+                                    pickerController.delegate = self;
+                                    [self presentViewController: pickerController
+                                                       animated: YES
+                                                     completion: nil];
+                                }];
+        
+        [actionSheet addAction: takeNewAction];
+    }
+    
+    
+    PSTAlertAction *chooseExistingAction =
+    [PSTAlertAction actionWithTitle: @"Choose existing"
+                            handler:^(PSTAlertAction *action) {
+                                UIImagePickerController *pickerController = [UIImagePickerController new];
+                                pickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;
+                                pickerController.delegate = self;
+                                [self presentViewController: pickerController
+                                                   animated: YES
+                                                 completion: nil];
+                            }];
+    
+    [actionSheet addAction: chooseExistingAction];
+    [actionSheet addCancelActionWithHandler: nil];
+    
+    [actionSheet showWithSender: nil
+                     controller: self
+                       animated: YES
+                     completion: nil];
+}
+
+#pragma mark - UIImagePickerControllerDelegate
+
+- (void) imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
+{
+    UIImage *image = [info valueForKey: UIImagePickerControllerOriginalImage];
+    //TODO: use the image
+    [picker dismissViewControllerAnimated: YES completion: nil];
 }
 
 @end

--- a/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
+++ b/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
@@ -21,6 +21,7 @@
 #import "BeMyEyes-Swift.h"
 #import <PSTAlertController.h>
 
+
 #define BMEHelperSnoozeAmount0 0.0f
 #define BMEHelperSnoozeAmount25 3600.0f
 #define BMEHelperSnoozeAmount50 6 * 3600.0f
@@ -488,7 +489,9 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
 - (void) imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
 {
     UIImage *image = [info valueForKey: UIImagePickerControllerOriginalImage];
-    //TODO: use the image
+    
+    self.profileImageView.image = image;
+    self.user.profileImage = image;
     [picker dismissViewControllerAnimated: YES completion: nil];
 }
 

--- a/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
+++ b/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
@@ -127,11 +127,13 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
     panGesture.delegate = self;
     [self.view addGestureRecognizer:panGesture];
     
-    UITapGestureRecognizer *photoTapRecognizer =
-    [[UITapGestureRecognizer alloc] initWithTarget: self
-                                            action: @selector(profileImageViewTapped:)];
-    [self.profileImageView addGestureRecognizer: photoTapRecognizer];
-    self.profileImageView.userInteractionEnabled = YES;
+    if ([self.user isNative]) {
+        UITapGestureRecognizer *photoTapRecognizer =
+        [[UITapGestureRecognizer alloc] initWithTarget: self
+                                                action: @selector(profileImageViewTapped:)];
+        [self.profileImageView addGestureRecognizer: photoTapRecognizer];
+        self.profileImageView.userInteractionEnabled = YES;
+    }
     
     [self snapSnoozeSliderToStep:BMESnoozeStep0 animated:NO];
     
@@ -434,15 +436,19 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
 
 - (void) profileImageViewTapped: (UITapGestureRecognizer*) tapRecognizer
 {
+    NSString *actionSheetTitle = NSLocalizedStringFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_ACTION_SHEET_TITLE, BMEHelperMainLocalizationTable, NULL);
+    
     PSTAlertController *actionSheet =
-    [PSTAlertController alertControllerWithTitle: @"Add profile photo"
+    [PSTAlertController alertControllerWithTitle: actionSheetTitle
                                          message: nil
                                   preferredStyle: PSTAlertControllerStyleActionSheet];
     
     if ([UIImagePickerController isSourceTypeAvailable: UIImagePickerControllerSourceTypeCamera])
     {
+        NSString *takeNewActionTitle = NSLocalizedStringFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_TAKE_NEW, BMEHelperMainLocalizationTable, NULL);
+        
         PSTAlertAction *takeNewAction =
-        [PSTAlertAction actionWithTitle: @"Take new"
+        [PSTAlertAction actionWithTitle: takeNewActionTitle
                                 handler:^(PSTAlertAction *action) {
                                     UIImagePickerController *pickerController = [UIImagePickerController new];
                                     pickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
@@ -455,9 +461,10 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
         [actionSheet addAction: takeNewAction];
     }
     
+    NSString *chooseExistingTitle = NSLocalizedStringFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_CHOOSE_EXISTING, BMEHelperMainLocalizationTable, NULL);
     
     PSTAlertAction *chooseExistingAction =
-    [PSTAlertAction actionWithTitle: @"Choose existing"
+    [PSTAlertAction actionWithTitle: chooseExistingTitle
                             handler:^(PSTAlertAction *action) {
                                 UIImagePickerController *pickerController = [UIImagePickerController new];
                                 pickerController.sourceType = UIImagePickerControllerSourceTypePhotoLibrary;

--- a/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
+++ b/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
@@ -437,7 +437,7 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
 
 - (void) profileImageViewTapped: (UITapGestureRecognizer*) tapRecognizer
 {
-    NSString *actionSheetTitle = NSLocalizedStringFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_ACTION_SHEET_TITLE, BMEHelperMainLocalizationTable, NULL);
+    NSString *actionSheetTitle = MKLocalizedFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_ACTION_SHEET_TITLE, BMEHelperMainLocalizationTable);
     
     PSTAlertController *actionSheet =
     [PSTAlertController alertControllerWithTitle: actionSheetTitle
@@ -446,7 +446,7 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
     
     if ([UIImagePickerController isSourceTypeAvailable: UIImagePickerControllerSourceTypeCamera])
     {
-        NSString *takeNewActionTitle = NSLocalizedStringFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_TAKE_NEW, BMEHelperMainLocalizationTable, NULL);
+        NSString *takeNewActionTitle = MKLocalizedFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_TAKE_NEW, BMEHelperMainLocalizationTable);
         
         PSTAlertAction *takeNewAction =
         [PSTAlertAction actionWithTitle: takeNewActionTitle
@@ -462,7 +462,7 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
         [actionSheet addAction: takeNewAction];
     }
     
-    NSString *chooseExistingTitle = NSLocalizedStringFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_CHOOSE_EXISTING, BMEHelperMainLocalizationTable, NULL);
+    NSString *chooseExistingTitle = MKLocalizedFromTable(BME_HELPER_MAIN_PROFILE_PHOTO_CHOOSE_EXISTING, BMEHelperMainLocalizationTable);
     
     PSTAlertAction *chooseExistingAction =
     [PSTAlertAction actionWithTitle: chooseExistingTitle
@@ -489,9 +489,9 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
 - (void) imagePickerController:(UIImagePickerController *)picker didFinishPickingMediaWithInfo:(NSDictionary *)info
 {
     UIImage *image = [info valueForKey: UIImagePickerControllerOriginalImage];
-    
-    self.profileImageView.image = image;
-    self.user.profileImage = image;
+    UIImage *imageScaled = [image scaleToProfileImageSize];
+    self.profileImageView.image = imageScaled;
+    self.user.profileImage = imageScaled;
     [picker dismissViewControllerAnimated: YES completion: nil];
 }
 

--- a/BeMyEyes/Source/Extensions.swift
+++ b/BeMyEyes/Source/Extensions.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import AVFoundation
 
 extension UIDevice {
 	
@@ -14,4 +15,25 @@ extension UIDevice {
 		return UIDevice.currentDevice().userInterfaceIdiom == .Pad
 	}
 	
+}
+
+extension UIImage {
+    func scaleToProfileImageSize() -> UIImage {
+        
+        let profileImageSize = CGSizeMake(200, 200)
+        
+        let hasAlpha = false
+        let scale: CGFloat = 0.0 // Automatically use scale factor of main screen
+        
+        let desiredRect = CGRectMake(0, 0, profileImageSize.width, profileImageSize.height)
+        let rect = AVMakeRectWithAspectRatioInsideRect(self.size, desiredRect)
+        
+        UIGraphicsBeginImageContextWithOptions(rect.size, !hasAlpha, scale)
+        self.drawInRect(CGRect(origin: CGPointZero, size: rect.size))
+        
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        
+        return scaledImage
+    }
 }

--- a/BeMyEyes/Source/MKLocalizationKeys.h
+++ b/BeMyEyes/Source/MKLocalizationKeys.h
@@ -21718,6 +21718,39 @@ static NSString * const POST_CALL_VIEW_CONTROLLER_STEP_2 = @"POST_CALL_VIEW_CONT
  */
 static NSString * const POST_CALL_VIEW_CONTROLLER_BLIND_NAME = @"POST_CALL_VIEW_CONTROLLER_BLIND_NAME";
 
+#warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_HELPER_MAIN_PROFILE_PHOTO_TAKE_NEW'
+/*!
+ * "Take new"
+
+ * All translations:
+
+ * @b en@: "Take new"
+
+ */
+static NSString * const BME_HELPER_MAIN_PROFILE_PHOTO_TAKE_NEW = @"BME_HELPER_MAIN_PROFILE_PHOTO_TAKE_NEW";
+
+#warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_HELPER_MAIN_PROFILE_PHOTO_CHOOSE_EXISTING'
+/*!
+ * "Choose existing"
+
+ * All translations:
+
+ * @b en@: "Choose existing"
+
+ */
+static NSString * const BME_HELPER_MAIN_PROFILE_PHOTO_CHOOSE_EXISTING = @"BME_HELPER_MAIN_PROFILE_PHOTO_CHOOSE_EXISTING";
+
+#warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_HELPER_MAIN_PROFILE_PHOTO_ACTION_SHEET_TITLE'
+/*!
+ * "Add profile photo"
+
+ * All translations:
+
+ * @b en@: "Add profile photo"
+
+ */
+static NSString * const BME_HELPER_MAIN_PROFILE_PHOTO_ACTION_SHEET_TITLE = @"BME_HELPER_MAIN_PROFILE_PHOTO_ACTION_SHEET_TITLE";
+
 #warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_LOGIN_ALERT_FACEBOOK_ACCESS_DENIED_OK'
 /*!
  * "OK"

--- a/BeMyEyes/Source/Models/BMEUser.h
+++ b/BeMyEyes/Source/Models/BMEUser.h
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSInteger, BMEUserType) {
 
 - (BOOL)isHelper;
 - (BOOL)isBlind;
+- (BOOL)isNative;
 - (int)pointsToNextLevel;
 - (double)levelProgress;
 

--- a/BeMyEyes/Source/Models/BMEUser.h
+++ b/BeMyEyes/Source/Models/BMEUser.h
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSInteger, BMEUserType) {
 @property (readonly, nonatomic) NSArray *lastPointEntries;
 @property (readonly, nonatomic) NSArray *completedTasks;
 @property (readonly, nonatomic) NSArray *remainingTasks;
-@property (readonly, nonatomic) UIImage *profileImage;
+@property (strong, nonatomic) UIImage *profileImage;
 
 - (BOOL)isHelper;
 - (BOOL)isBlind;

--- a/BeMyEyes/Source/Models/BMEUser.m
+++ b/BeMyEyes/Source/Models/BMEUser.m
@@ -82,6 +82,10 @@
     return self.role == BMERoleBlind;
 }
 
+- (BOOL)isNative {
+    return self.type == BMEUserTypeNative;
+}
+
 - (int)pointsToNextLevel {
     return self.nextLevel == nil ? 0 : self.nextLevel.threshold.integerValue - self.totalPoints.integerValue;
 }

--- a/BeMyEyes/en.lproj/BMEHelperMainLocalizationTable.strings
+++ b/BeMyEyes/en.lproj/BMEHelperMainLocalizationTable.strings
@@ -85,3 +85,11 @@
 /* Snooze status text when not snoozing */
 "BME_HELPER_MAIN_SNOOZE_STATUS_NOT_SNOOZING_TEXT" = "You are currently active";
 
+/* Option title in actions sheet displayed when the profile image view is tapped */
+"BME_HELPER_MAIN_PROFILE_PHOTO_TAKE_NEW" = "Take new";
+
+/* Option title in action sheet displayed when the profile image view is tapped */
+"BME_HELPER_MAIN_PROFILE_PHOTO_CHOOSE_EXISTING" = "Choose existing";
+
+/* Title of the action sheet displayed when the profile image view is tapped */
+"BME_HELPER_MAIN_PROFILE_PHOTO_ACTION_SHEET_TITLE" = "Add profile photo";


### PR DESCRIPTION
Issue #23 

* Profile image view is tappable for non-Facebook users
* When the user taps it an action sheet appears offering at most two options (depending on the image sources available): existing image or take new image.
* After the user has selected an image, it is saved using ```SDImageCache``` and the image view for the profile picture gets updated

@duemunk 