### PR TITLE
No languages selected alert view

### DIFF
--- a/BeMyEyes/Source/MKLocalizationKeys.h
+++ b/BeMyEyes/Source/MKLocalizationKeys.h
@@ -21956,6 +21956,50 @@ static NSString * const BME_ACCESS_NOTIFICATION_ACTION_ANSWER = @"BME_ACCESS_NOT
  */
 static NSString * const BME_ACCESS_NOTIFICATION_ACTION_DISMISS = @"BME_ACCESS_NOTIFICATION_ACTION_DISMISS";
 
+#warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_LANGUAGES_ALERT_NO_LANGS_SELECTED'
+/*!
+ * "You have no languages selected"
+
+ * All translations:
+
+ * @b en@: "You have no languages selected"
+
+ */
+static NSString * const BME_LANGUAGES_ALERT_NO_LANGS_SELECTED = @"BME_LANGUAGES_ALERT_NO_LANGS_SELECTED";
+
+#warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_LANGUAGES_ALERT_PROCEED_QUESTION'
+/*!
+ * "Are you sure you want to proceed?"
+
+ * All translations:
+
+ * @b en@: "Are you sure you want to proceed?"
+
+ */
+static NSString * const BME_LANGUAGES_ALERT_PROCEED_QUESTION = @"BME_LANGUAGES_ALERT_PROCEED_QUESTION";
+
+#warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_YES'
+/*!
+ * "Yes"
+
+ * All translations:
+
+ * @b en@: "Yes"
+
+ */
+static NSString * const BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_YES = @"BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_YES";
+
+#warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_NO'
+/*!
+ * "No"
+
+ * All translations:
+
+ * @b en@: "No"
+
+ */
+static NSString * const BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_NO = @"BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_NO";
+
 #warning Missing languages ar, cs, da, de, el, es, fi, fr, he, hi, hr, hu, it, ja, ko, nb, nl, pl, pt-BR, pt, ro, ru, sk, sr, sv, tr, uk, ur, vi, zh-Hans, zh-Hant for key 'BME_LOGIN_ALERT_FACEBOOK_ACCESS_DENIED_OK'
 /*!
  * "OK"

--- a/BeMyEyes/en.lproj/BMELanguagesLocalizationTable.strings
+++ b/BeMyEyes/en.lproj/BMELanguagesLocalizationTable.strings
@@ -10,3 +10,15 @@
 /* Title in alert view shown when the languages could not be saved */
 "BME_LANGUAGES_ALERT_COULD_NOT_SAVE_TITLE" = "Could not save";
 
+/* Title in alert view shown when no languages have been selected */
+"BME_LANGUAGES_ALERT_NO_LANGS_SELECTED" = "You have no languages selected";
+
+/* Message in alert view shown when no languages have been selected */
+"BME_LANGUAGES_ALERT_PROCEED_QUESTION" = "Are you sure you want to proceed?";
+
+/* Positive answer to alert view shown when no languages have been selected */
+"BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_YES" = "Yes";
+
+/* Negative answer to alert view shown when no languages have been selected */
+"BME_LANGUAGES_ALERT_PROCEED_QUESTION_ANSWER_NO" = "No";
+


### PR DESCRIPTION
Fixes #42 

* An alert view is shown when the user selects no languages on the languages page and presses the "Save" button
* Added translations for the strings displayed in the alert view

@duemunk 