### PR TITLE
Fixing a crash + selecting front facing camera

### DIFF
--- a/BeMyEyes/Localization/Base.lproj/Main.storyboard
+++ b/BeMyEyes/Localization/Base.lproj/Main.storyboard
@@ -2070,7 +2070,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
         <!--Helper Welcome View Controller-->
         <scene sceneID="5fN-0s-BVT">
             <objects>
-                <viewController storyboardIdentifier="HelperWelcome" id="RSG-SW-ISv" customClass="HelperWelcomeViewController" customModule="BeMyEyes" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BMEHelperWelcomeViewController" id="RSG-SW-ISv" customClass="HelperWelcomeViewController" customModule="BeMyEyes" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="2ij-MZ-reS"/>
                         <viewControllerLayoutGuide type="bottom" id="IB5-kn-QvV"/>

--- a/BeMyEyes/Localization/Base.lproj/Main.storyboard
+++ b/BeMyEyes/Localization/Base.lproj/Main.storyboard
@@ -2070,7 +2070,7 @@ You may under no circumstances share any nude, unlawful, hateful or sexually sug
         <!--Helper Welcome View Controller-->
         <scene sceneID="5fN-0s-BVT">
             <objects>
-                <viewController storyboardIdentifier="BMEHelperWelcomeViewController" id="RSG-SW-ISv" customClass="HelperWelcomeViewController" customModule="BeMyEyes" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HelperWelcome" id="RSG-SW-ISv" customClass="HelperWelcomeViewController" customModule="BeMyEyes" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="2ij-MZ-reS"/>
                         <viewControllerLayoutGuide type="bottom" id="IB5-kn-QvV"/>

--- a/BeMyEyes/Source/BMEGlobal.temp.h
+++ b/BeMyEyes/Source/BMEGlobal.temp.h
@@ -45,7 +45,7 @@
 #define BMECallControllerIdentifier @"Call"
 #define BMESecretSettingsControllerIdentifier @"SecretSettings"
 #define BMEDemoCallViewController @"DemoCall"
-#define BMEHelperWelcomeViewController @"BMEHelperWelcomeViewController"
+#define BMEHelperWelcomeViewController @"HelperWelcome"
 
 #define BMEDidLogInNotification @"BMEDidLogInNotification"
 #define BMEDidLogOutNotification @"BMEDidLogOutNotification"

--- a/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
+++ b/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
@@ -482,6 +482,7 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
                                 handler:^(PSTAlertAction *action) {
                                     UIImagePickerController *pickerController = [UIImagePickerController new];
                                     pickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
+                                    pickerController.cameraDevice=UIImagePickerControllerCameraDeviceFront;
                                     pickerController.delegate = self;
                                     [self presentViewController: pickerController
                                                        animated: YES

--- a/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
+++ b/BeMyEyes/Source/Controllers/BMEHelperMainViewController.m
@@ -482,7 +482,7 @@ typedef NS_ENUM(NSInteger, BMESnoozeStep) {
                                 handler:^(PSTAlertAction *action) {
                                     UIImagePickerController *pickerController = [UIImagePickerController new];
                                     pickerController.sourceType = UIImagePickerControllerSourceTypeCamera;
-                                    pickerController.cameraDevice=UIImagePickerControllerCameraDeviceFront;
+                                    pickerController.cameraDevice = UIImagePickerControllerCameraDeviceFront;
                                     pickerController.delegate = self;
                                     [self presentViewController: pickerController
                                                        animated: YES


### PR DESCRIPTION
* Fixed a crash occurring after creating a new user. The welcome screen in the storyboard had a different ID then the one used in code.
* Front facing camera is used when the user chooses to add a profile picture by taking a new one.

@duemunk 