### PR TITLE
Properties referencing a block should copy on assignment

### DIFF
--- a/BeMyEyes/Source/Application/BMEAccessControlHandler.m
+++ b/BeMyEyes/Source/Application/BMEAccessControlHandler.m
@@ -12,7 +12,7 @@
 
 @interface BMEAccessControlHandler() <UIAlertViewDelegate>
 
-@property (strong, nonatomic) void (^notificationsCompletion)(BOOL isEnabled, BOOL validToken);
+@property (copy, nonatomic) void (^notificationsCompletion)(BOOL isEnabled, BOOL validToken);
 
 @end
 


### PR DESCRIPTION
By default blocks are created on the stack and need to be copied if they need to persist beyond the current method call.